### PR TITLE
Change "initial code" to emit null

### DIFF
--- a/desktop-client/src/jvmMain/kotlin/com/kotlinconf/workshop/kettle/network/KettleService.kt
+++ b/desktop-client/src/jvmMain/kotlin/com/kotlinconf/workshop/kettle/network/KettleService.kt
@@ -79,7 +79,7 @@ class KettleService {
 
     fun observeTemperature(): Flow<CelsiusTemperature?> = flow {
         // initial code:
-//        emit(null)
+//        (no code)
         while (true) {
             delay(1000)
             emit(getTemperature())

--- a/desktop-client/src/jvmMain/kotlin/com/kotlinconf/workshop/kettle/network/KettleService.kt
+++ b/desktop-client/src/jvmMain/kotlin/com/kotlinconf/workshop/kettle/network/KettleService.kt
@@ -79,7 +79,7 @@ class KettleService {
 
     fun observeTemperature(): Flow<CelsiusTemperature?> = flow {
         // initial code:
-//        emit(getTemperature())
+//        emit(null)
         while (true) {
             delay(1000)
             emit(getTemperature())


### PR DESCRIPTION
I think it'll be a bit clearer if we just stub the code entirely, to avoid the confusion of "it loads the temperature, but doesn't update. And it'll make people use the `emit` function themselves explicitly :)