### PR TITLE
Always `call.respond` in Ktor

### DIFF
--- a/server/src/main/kotlin/com/kotlinconf/workshop/plugins/KettleRouting.kt
+++ b/server/src/main/kotlin/com/kotlinconf/workshop/plugins/KettleRouting.kt
@@ -14,9 +14,11 @@ fun Application.configureKettleRouting(kettle: Kettle) {
     routing {
         post("kettle/on") {
             kettle.switchOn()
+            call.respond(HttpStatusCode.OK)
         }
         post("kettle/off") {
             kettle.switchOff()
+            call.respond(HttpStatusCode.OK)
         }
         get("kettle/temperature") {
             val failureProbability = call.request.queryParameters["failure"]?.toDouble() ?: 0.0

--- a/server/src/main/kotlin/com/kotlinconf/workshop/plugins/WalletRouting.kt
+++ b/server/src/main/kotlin/com/kotlinconf/workshop/plugins/WalletRouting.kt
@@ -1,5 +1,6 @@
 package com.kotlinconf.workshop.plugins
 
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -11,6 +12,7 @@ fun Application.configureWalletRouting() {
         route("wallet") {
             get("/earn") {
                 money++
+                call.respond(HttpStatusCode.OK)
             }
             get("/money") {
                 call.respondText(money.toString())


### PR DESCRIPTION
This fixes a problem found during the workshop, in which sometimes Ktor would not respond for the Kettle service