### PR TITLE
Implement `ChatRouting` using `WebSocketServerSession` as receiver

### DIFF
--- a/server/src/main/kotlin/com/kotlinconf/workshop/plugins/ChatRouting.kt
+++ b/server/src/main/kotlin/com/kotlinconf/workshop/plugins/ChatRouting.kt
@@ -4,38 +4,34 @@ import com.kotlinconf.workshop.ChatMessage
 import io.ktor.server.application.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 fun Application.configureChatRouting(chat: Chat = Chat()) {
     routing {
         webSocket("/chat") {
-            handleSocket(this, chat)
+            handleSocket(chat)
         }
     }
 }
 
 // Task: Implement chat server using SharedFlow
-suspend fun handleSocket(
-    socket: WebSocketServerSession,
-    chat: Chat
-) {
-    coroutineScope {
-        launch {
-            // use socket.receiveDeserialized<ChatMessage>() to receive a message from the WebSocket
-            while (true) {
-                val message = socket.receiveDeserialized<ChatMessage>()
-                chat.broadcastMessage(message)
-            }
+suspend fun WebSocketServerSession.handleSocket(chat: Chat) {
+    launch {
+        // use sendSerialized(message) to send a message to the WebSocket
+        chat.messageFlow.collect {
+            sendSerialized(it)
         }
-        launch {
-            // use session.sendSerialized(message) to send a message to the WebSocket
-            chat.messageFlow.collect {
-                socket.sendSerialized(it)
-            }
-        }
+    }
+
+    // use receiveDeserialized<ChatMessage>() to receive a message from the WebSocket
+    while (isActive) {
+        val message = receiveDeserialized<ChatMessage>()
+        chat.broadcastMessage(message)
     }
 }
 


### PR DESCRIPTION
According to the [documentation](https://ktor.io/docs/server-websockets.html#handle-multiple-session), the right way to handle multiple clients in websockets is to `launch` the observers of the `Flow`, but keep the `receiveDeserialized` in the coroutine itself.

Furthermore, `WebSocketSession` is `CoroutineScope`, so there's no need to use `coroutineScope` in this case. This may give students an example of how extension functions over `CoroutineScope` are useful.